### PR TITLE
changed eslint from beta 6 to beta 10 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Production-ready, one-click deployable boilerplate for [React](http://facebook.g
 
 ## One-click production deployment
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/alexkuz/flask-react-boilerplate)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/patrickxie/flask-react-boilerplate)
 
 This is what you will get:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Production-ready, one-click deployable boilerplate for [React](http://facebook.g
 
 ## One-click production deployment
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/patrickxie/flask-react-boilerplate)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/alexkuz/flask-react-boilerplate)
 
 This is what you will get:
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "assets-webpack-plugin": "3.2.0",
     "babel": "6.3.26",
     "babel-core": "6.3.26",
-    "babel-eslint": "5.0.0-beta6",
+    "babel-eslint": "5.0.0-beta10",
     "babel-jest": "6.0.1",
     "babel-loader": "6.2.1",
     "babel-plugin-react-transform": "2.0.0",


### PR DESCRIPTION
There were a few errors when trying to deploy on heroku with eslint beta 6, after doing some research I found that eslint-beta-9+ makes deploy error free.

Btw this is a nice boilerplate to kickstart a project for a python react dev, thanks for the good work.
