### PR TITLE
Deleted npm run dist from Procfile web process

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: npm run dist && npm run gunicorn
+web:npm run gunicorn
 server: npm run gunicorn
 webpackdev: npm start
 initdb: python server/initdb.py


### PR DESCRIPTION
The reason I deleted this was because, after I started using this boilerplate to build my front end, as I piled on more and more npm libraries, I was hit with <code>Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch</code>.

After troubleshooting with Heroku support, it turns out that if we are specifying  <code>npm run dist</code> in the procfile, it will run the distribution bundle script while the dyno is booting up. Which could take a very long time (took me over 1 minute, and heroku's dyno have a 60second boot time limit, meaning it will shut down after failure to finish booting after 60seconds). 

Since we are running the <code>npm run dist</code> in the <code>postinstall</code> npm script in the package.json already anyway, we can eliminate the long boot time problem that people might have once their npm dependencies get big enough.

This way we are not obstructing the heroku dyno from booting up and running the server, and the <code>npm run dist</code> will still be ran when the app is being built by npm, which happens after the web server is booted.
